### PR TITLE
Added 'checkout success' event to the controller

### DIFF
--- a/source/app/code/community/Yireo/CheckoutTester/controllers/IndexController.php
+++ b/source/app/code/community/Yireo/CheckoutTester/controllers/IndexController.php
@@ -50,6 +50,7 @@ class Yireo_CheckoutTester_IndexController extends Mage_Core_Controller_Front_Ac
 
         // Load the layout
         $this->loadLayout();
+        Mage::dispatchEvent('checkout_onepage_controller_success_action', array('order_ids' => array($orderId)));
         $this->renderLayout();
     }
 }


### PR DESCRIPTION
Nice idea with the checkout success page tester, but it lacks one very important feature, it doesn't provide any data for the tracking scripts (especially GA, affiliate programs or retargeting tools). As they rely on the observers gathering data from either **checkout_onepage_controller_success_action** or **checkout_multishipping_controller_success_action** event, I've modified the IndexController.php code to fire the most commonly used checkout_onepage_controller_success_action event and now tracking scripts (like GA e-commerce transaction tracking) appear on the success page preview.
