### PR TITLE
Make modman file more robust

### DIFF
--- a/modman
+++ b/modman
@@ -1,4 +1,4 @@
 # Modman file
 source/app/code/community/Yireo/CheckoutTester app/code/community/Yireo/CheckoutTester
 source/app/design/frontend/base/default/layout/* app/design/frontend/base/default/layout/
-source/app/etc/modules/Yireo_CheckoutTester.xml app/etc/modules/
+source/app/etc/modules/Yireo_CheckoutTester.xml app/etc/modules/Yireo_CheckoutTester.xml


### PR DESCRIPTION
At least modman-php trims trailing slashes, so that a non-wildcard entry cannot be linked *into* a directory like this