### PR TITLE
Check if module output is enabled

### DIFF
--- a/source/app/code/community/Yireo/CheckoutTester/controllers/IndexController.php
+++ b/source/app/code/community/Yireo/CheckoutTester/controllers/IndexController.php
@@ -33,6 +33,10 @@ class Yireo_CheckoutTester_IndexController extends Mage_Core_Controller_Front_Ac
         if (Mage::helper('checkouttester')->hasAccess() == false) {
             die('Access denied');
         }
+        // Check if module output is enabled
+        if (!Mage::helper('checkouttester')->enabled()) {
+            die('Module output disabled');
+        }
 
         // Fetch the order
         $order = $this->getOrder();


### PR DESCRIPTION
Some success pages show sensitive information. Using this module you can see the sensitive information of any order by just passing the entity id as a parameter to the URL (ok, that is if you don't use the IP block).

I wanted an easy way to completely disable the module in my production environment. I saw that `Yireo_CheckoutTester_Helper_Data::enabled()` was already in place to check the module output setting. It was just never called. So that is exactly what I did: call the method and let the module show a message if the module output was disabled, just like the IP block.