### PR TITLE
Move 'checkout/session' model's instantiation out of constructor

### DIFF
--- a/source/app/code/community/Yireo/CheckoutTester/controllers/IndexController.php
+++ b/source/app/code/community/Yireo/CheckoutTester/controllers/IndexController.php
@@ -38,9 +38,18 @@ class Yireo_CheckoutTester_IndexController extends Mage_Core_Controller_Front_Ac
     {
         $this->helper = Mage::helper('checkouttester');
         $this->orderModel = Mage::getModel('sales/order');
-        $this->checkoutSession = Mage::getModel('checkout/session');
 
         parent::_construct();
+    }
+
+    /**
+     * @return Mage_Checkout_Model_Session
+     */
+    public function getCheckoutSession() {
+        if(!$this->checkoutSession) {
+            $this->checkoutSession = Mage::getModel('checkout/session');
+        }
+        return $this->checkoutSession;
     }
 
     /**
@@ -147,7 +156,7 @@ class Yireo_CheckoutTester_IndexController extends Mage_Core_Controller_Front_Ac
         }
 
         // Load the session with this order
-        $this->checkoutSession->setLastOrderId($order->getId())
+        $this->getCheckoutSession()->setLastOrderId($order->getId())
             ->setLastRealOrderId($order->getIncrementId());
 
         // Optionally dispatch an event


### PR DESCRIPTION
The checkout success page CAN use customer/session singleton to decide to display some informations (like link to the order page in customer account etc...)
It seems that instantiating the session/checkout object too early (here, in constructor) can 'break'  the customer/session object.
For reference : Allan Storm wrote "Early Magento Session Instantiation is Harmful" : http://alanstorm.com/magento_sessions_early


